### PR TITLE
Add bbox option for harmonizer pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ candidates = score_candidates(candidates)
 candidates.to_parquet("data/interim/acre_candidates.parquet")
 ```
 
+### Pythonスクリプト
+
+Notebook を使わずコマンドラインから実行する場合は `scripts/run_harmonizer.py`
+を利用します。BBOX を変更したい場合は `--bbox` オプションで緯度経度を指定します。
+
+```bash
+python scripts/run_harmonizer.py --bbox -70.5 -11.5 -66.5 -8.5
+```
+
 ## プロジェクト構成
 
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,6 +37,7 @@ python scripts/run_harmonizer.py --rivers_path データ/HydroRIVERS.shp --gsw_p
 - `--gsw_path PATH`: GSW occurrenceのTIFFファイルパス（デフォルト: `data/raw/occurrence_70W_10Sv1_4_2021.tif`）
 - `--output_path PATH`: 出力ファイルパス（デフォルト: `data/interim/acre_candidates.parquet`）
 - `--visualize`: 処理結果を可視化する（デフォルト: False）
+- `--bbox LON_MIN LAT_MIN LON_MAX LAT_MAX`: 対象領域のBBoxを指定（デフォルト: `-70.5 -11.5 -66.5 -8.5`）
 
 ### 処理ステップ
 

--- a/scripts/run_harmonizer.py
+++ b/scripts/run_harmonizer.py
@@ -45,6 +45,7 @@ from tamagawa_to_z.harmonizer import (
     make_bbox_gdf, process_toponyms,
     attach_distance, water_occurrence, filter_candidates, score_candidates
 )
+from tamagawa_to_z.harmonizer.preprocess import ACRE_BBOX
 
 
 def parse_args():
@@ -92,7 +93,17 @@ def parse_args():
         default=str(PROJECT_ROOT / 'data/raw/osm/norte-latest.osm.pbf'),
         help='PBFファイルのパス'
     )
-    
+
+    # BBOX オプション
+    parser.add_argument(
+        '--bbox',
+        type=float,
+        nargs=4,
+        metavar=('LON_MIN', 'LAT_MIN', 'LON_MAX', 'LAT_MAX'),
+        default=list(ACRE_BBOX.bounds),
+        help='対象領域のBBOX (lon_min lat_min lon_max lat_max)'
+    )
+
     return parser.parse_args()
 
 
@@ -122,12 +133,12 @@ def ensure_data_dirs():
     logger.info("データディレクトリを確認しました")
 
 
-def step1_define_bbox(visualize=False):
+def step1_define_bbox(bbox_coords, visualize=False):
     """S-1: 対象地域のBBox定義"""
     logger.info("S-1: 対象地域のBBox定義を実行中...")
-    
+
     # BBoxの作成
-    bbox_gdf = make_bbox_gdf()
+    bbox_gdf = make_bbox_gdf(*bbox_coords)
     bbox = bbox_gdf.geometry.iloc[0]
     logger.info(f"対象領域の境界: {bbox.bounds}")
     
@@ -329,7 +340,7 @@ def main():
         logger.warning("一部のデータファイルが見つかりません。可能な処理のみ実行します。")
     
     # S-1: 対象地域のBBox定義
-    bbox_gdf = step1_define_bbox(visualize=args.visualize)
+    bbox_gdf = step1_define_bbox(args.bbox, visualize=args.visualize)
     
     # S-2: 水場系トポニムの抽出
     names = step2_extract_toponyms(bbox_gdf, visualize=args.visualize, use_pyrosm=True, pbf_path=args.pbf_path)

--- a/src/tamagawa_to_z/harmonizer/preprocess.py
+++ b/src/tamagawa_to_z/harmonizer/preprocess.py
@@ -19,15 +19,28 @@ from pathlib import Path
 # S-1: 対象地域のBBox定義
 ACRE_BBOX = box(-70.5, -11.5, -66.5, -8.5)   # lon_min, lat_min, lon_max, lat_max
 
-def make_bbox_gdf():
-    """Returns the BBox of Western Upper Madeira River, Acre State as a GeoDataFrame
-    
+def make_bbox_gdf(
+    lon_min: float = ACRE_BBOX.bounds[0],
+    lat_min: float = ACRE_BBOX.bounds[1],
+    lon_max: float = ACRE_BBOX.bounds[2],
+    lat_max: float = ACRE_BBOX.bounds[3],
+) -> gpd.GeoDataFrame:
+    """指定した範囲のBBoxをGeoDataFrameとして返す
+
+    Parameters
+    ----------
+    lon_min, lat_min, lon_max, lat_max : float, optional
+        バウンディングボックスの四隅の座標。
+        省略時はアクレ州西部 (``ACRE_BBOX``) を使用する。
+
     Returns
     -------
     gpd.GeoDataFrame
         GeoDataFrame containing the BBox
     """
-    return gpd.GeoDataFrame({"id": [1]}, geometry=[ACRE_BBOX], crs="EPSG:4326")
+
+    bbox = box(lon_min, lat_min, lon_max, lat_max)
+    return gpd.GeoDataFrame({"id": [1]}, geometry=[bbox], crs="EPSG:4326")
 
 
 # S-2: 水場系トポニムの抽出


### PR DESCRIPTION
## Summary
- allow custom bbox for `make_bbox_gdf`
- accept `--bbox` option in `run_harmonizer.py`
- document CLI bbox usage in README files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68515d523a048326acc79fa6a64dc846