### PR TITLE
Switch inspector and researcher agents to Responses API

### DIFF
--- a/src/tamagawa_to_z/harmonizer/llm_layer/harmonize.py
+++ b/src/tamagawa_to_z/harmonizer/llm_layer/harmonize.py
@@ -49,7 +49,7 @@ class ToponymHarmonizer:
     def __init__(
         self,
         openai_api_key: Optional[str] = None,
-        model: str = "gpt-4o",
+        model: str = "o3",
         embedding_model: str = "sentence-transformers/distiluse-base-multilingual-cased-v2",
         max_retries: int = 3,
         timeout: float = 30.0,

--- a/src/tamagawa_to_z/inspector_agent/agent.py
+++ b/src/tamagawa_to_z/inspector_agent/agent.py
@@ -36,15 +36,12 @@ class InspectorValidatorAgent:
             OpenAI API キー（環境変数OPENAI_API_KEYからも読み込み可能）
         """
         self.client = OpenAI(api_key=api_key or os.getenv("OPENAI_API_KEY"))
-        self.assistant = None
-        self._create_assistant()
-    
-    def _create_assistant(self):
-        """OpenAI Assistant を作成する"""
-        self.assistant = self.client.beta.assistants.create(
-            name="InspectorValidator",
-            model="gpt-4o",
-            instructions="""あなたは多言語トポニム解析システムのInspector-Validator Agentです。
+        self.model = "o3"
+        self.tools = [
+            {"type": "function", "function": PROPOSE_SCHEMA},
+            {"type": "function", "function": DIAGNOSE_SCHEMA},
+        ]
+        self.instructions = """あなたは多言語トポニム解析システムのInspector-Validator Agentです。
 
 あなたの役割：
 1. 候補抽出結果のメトリクス（Recall@K, mAP, workload等）を分析
@@ -62,12 +59,8 @@ class InspectorValidatorAgent:
 2. add_exclude_mask: 除外マスクの追加（都市部、保護区域等）
 3. add_root_weight: 語根重み調整（igarapé、lagoa等の重要語彙）
 
-必ず具体的で実行可能な改善案を1件提案してください。""",
-            tools=[
-                {"type": "function", "function": PROPOSE_SCHEMA},
-                {"type": "function", "function": DIAGNOSE_SCHEMA}
-            ]
-        )
+必ず具体的で実行可能な改善案を1件提案してください。"""
+    
     
     def _build_analysis_prompt(self, metrics: Dict[str, float], 
                               spatial_stats: Dict[str, float],
@@ -166,18 +159,25 @@ class InspectorValidatorAgent:
         # 分析プロンプトの構築
         prompt = self._build_analysis_prompt(metrics, spatial_stats, meta_info)
         
-        # OpenAI Assistant による分析
-        thread = self.client.beta.threads.create()
-        self.client.beta.threads.messages.create(
+        # Responses API による分析
+        thread = self.client.responses.threads.create()
+        self.client.responses.threads.messages.create(
+            thread_id=thread.id,
+            role="system",
+            content=self.instructions,
+        )
+        self.client.responses.threads.messages.create(
             thread_id=thread.id,
             role="user",
-            content=prompt
+            content=prompt,
         )
-        
+
         # 実行と結果取得
-        run = self.client.beta.threads.runs.create_and_poll(
+        run = self.client.responses.threads.runs.create_and_poll(
             thread_id=thread.id,
-            assistant_id=self.assistant.id
+            model=self.model,
+            tools=self.tools,
+            tool_choice="auto"
         )
         
         # 結果の処理

--- a/src/tamagawa_to_z/researcher_agent/generator.py
+++ b/src/tamagawa_to_z/researcher_agent/generator.py
@@ -50,6 +50,28 @@ class ProposalGenerator:
         self.data = data
         self.failure_clusters = failure_clusters
         self.config = config
+        self.model = "o3"
+
+    def _run_llm(self, system_prompt: str, user_prompt: str, temperature: float = 0.3) -> str:
+        """Call the Responses API and return generated text."""
+        thread = self.client.responses.threads.create()
+        self.client.responses.threads.messages.create(
+            thread_id=thread.id,
+            role="system",
+            content=system_prompt,
+        )
+        self.client.responses.threads.messages.create(
+            thread_id=thread.id,
+            role="user",
+            content=user_prompt,
+        )
+        run = self.client.responses.threads.runs.create_and_poll(
+            thread_id=thread.id,
+            model=self.model,
+            temperature=temperature,
+        )
+        final = self.client.responses.threads.runs.retrieve(run.id)
+        return getattr(final.latest_message, "content", "")
     
     def generate(self, n: int = 3) -> List[Proposal]:
         """
@@ -135,17 +157,13 @@ Respond in this JSON format:
 }}"""
         
         try:
-            response = self.client.chat.completions.create(
-                model="gpt-4o",
-                messages=[
-                    {"role": "system", "content": "You are an expert in geospatial parameter optimization for archaeological site detection."},
-                    {"role": "user", "content": prompt}
-                ],
-                temperature=0.3
+            response_text = self._run_llm(
+                "You are an expert in geospatial parameter optimization for archaeological site detection.",
+                prompt,
+                temperature=0.3,
             )
-            
+
             # Parse JSON response
-            response_text = response.choices[0].message.content
             # Extract JSON from response (handle markdown code blocks)
             if '```json' in response_text:
                 json_part = response_text.split('```json')[1].split('```')[0]
@@ -214,16 +232,11 @@ Respond in this JSON format:
 }}"""
         
         try:
-            response = self.client.chat.completions.create(
-                model="gpt-4o",
-                messages=[
-                    {"role": "system", "content": "You are an expert in NLP pipeline optimization and prompt engineering."},
-                    {"role": "user", "content": prompt}
-                ],
-                temperature=0.4
+            response_text = self._run_llm(
+                "You are an expert in NLP pipeline optimization and prompt engineering.",
+                prompt,
+                temperature=0.4,
             )
-            
-            response_text = response.choices[0].message.content
             if '```json' in response_text:
                 json_part = response_text.split('```json')[1].split('```')[0]
             elif '{' in response_text:

--- a/src/tamagawa_to_z/researcher_agent/rca.py
+++ b/src/tamagawa_to_z/researcher_agent/rca.py
@@ -44,6 +44,28 @@ class RootCauseAnalyzer:
         """
         self.client = client
         self.data = data
+        self.model = "o3"
+
+    def _run_llm(self, system_prompt: str, user_prompt: str, temperature: float = 0.3) -> str:
+        """Call the Responses API and return generated text."""
+        thread = self.client.responses.threads.create()
+        self.client.responses.threads.messages.create(
+            thread_id=thread.id,
+            role="system",
+            content=system_prompt,
+        )
+        self.client.responses.threads.messages.create(
+            thread_id=thread.id,
+            role="user",
+            content=user_prompt,
+        )
+        run = self.client.responses.threads.runs.create_and_poll(
+            thread_id=thread.id,
+            model=self.model,
+            temperature=temperature,
+        )
+        final = self.client.responses.threads.runs.retrieve(run.id)
+        return getattr(final.latest_message, "content", "")
     
     def analyze(self) -> List[FailureCluster]:
         """
@@ -257,22 +279,16 @@ class RootCauseAnalyzer:
             # Prepare context for LLM
             cluster_type = cluster.get('type', 'unknown')
             failures = cluster.get('failures', [])
-            
+
             # Build analysis prompt
             prompt = self._build_analysis_prompt(cluster_type, failures)
-            
+
             # Call LLM
-            response = self.client.chat.completions.create(
-                model="gpt-4o",
-                messages=[
-                    {"role": "system", "content": self._get_system_prompt()},
-                    {"role": "user", "content": prompt}
-                ],
-                temperature=0.3
+            analysis = self._run_llm(
+                self._get_system_prompt(),
+                prompt,
+                temperature=0.3,
             )
-            
-            # Parse response
-            analysis = response.choices[0].message.content
             
             # Extract structured information
             root_cause, suggested_fix = self._parse_llm_response(analysis)


### PR DESCRIPTION
## Summary
- update inspector agent to use the Responses API with model `o3`
- refactor researcher agent modules to call the Responses API
- set default model `o3` for harmonizer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68556a6363308326b990849af2d79b75